### PR TITLE
Replace batch-and-wait DuckDB loading with producer-consumer pattern

### DIFF
--- a/linkml_solr/cli.py
+++ b/linkml_solr/cli.py
@@ -305,7 +305,7 @@ def start_server(schema, kill, container, url, core, port, sleep: int, create_sc
         '-e',
         f'SOLR_JAVA_MEM=-Xms{heap_size} -Xmx{heap_size}',
         '-e',
-        f'SOLR_OPTS=-Dsolr.ramBufferSizeMB={ram_buffer_mb} -Dsolr.jetty.request.header.size=65535',
+        f'SOLR_OPTS=-Dsolr.ramBufferSizeMB={ram_buffer_mb} -Dsolr.jetty.request.header.size=65535 -Dsolr.jetty.http.idleTimeout=300000',
         'solr:8',
         'solr-precreate',
         core]

--- a/linkml_solr/utils/solr_bulkload.py
+++ b/linkml_solr/utils/solr_bulkload.py
@@ -11,22 +11,32 @@ import time
 import os
 from linkml_runtime.linkml_model.meta import SchemaDefinition, SlotDefinitionName
 import requests
+from urllib3.util.retry import Retry
+
+logger = logging.getLogger(__name__)
 
 # Global session for connection pooling
 _session_lock = threading.Lock()
 _global_session = None
 
 def get_http_session():
-    """Get a shared HTTP session with connection pooling"""
+    """Get a shared HTTP session with connection pooling and transport-level retry"""
     global _global_session
     with _session_lock:
         if _global_session is None:
             _global_session = requests.Session()
-            # Configure connection pooling for parallel uploads
+            # Transport-level retry for connection errors and server errors
+            retry_strategy = Retry(
+                total=3,
+                backoff_factor=1,
+                status_forcelist=[502, 503, 504],
+                allowed_methods=["POST", "GET"],
+            )
             adapter = requests.adapters.HTTPAdapter(
                 pool_connections=20,
                 pool_maxsize=20,
-                pool_block=True
+                pool_block=True,
+                max_retries=retry_strategy,
             )
             _global_session.mount('http://', adapter)
             _global_session.mount('https://', adapter)
@@ -91,18 +101,28 @@ def bulkload_file(f,
         ct = 'application/json'
     else:
         raise Exception(f'Unknown format {format}')
-    # Use direct HTTP with connection pooling for better performance
-    try:
-        session = get_http_session()
-        with open(f, 'rb') as file_data:
-            response = session.post(url, data=file_data, headers={'Content-Type': ct}, timeout=300)
-            print(f"Uploaded {f}: {response.status_code}")
-            if response.status_code != 200:
-                print(f"Error response: {response.text}")
-            return response.status_code == 200
-    except Exception as e:
-        print(f"Error uploading {f}: {e}")
-        return False
+    # Use direct HTTP with connection pooling and retry for better reliability
+    max_retries = 3
+    session = get_http_session()
+    for attempt in range(1, max_retries + 1):
+        try:
+            with open(f, 'rb') as file_data:
+                response = session.post(url, data=file_data, headers={'Content-Type': ct}, timeout=300)
+            if response.status_code == 200:
+                print(f"Uploaded {f}: {response.status_code}")
+                return True
+            logger.warning(f"Solr returned {response.status_code} uploading {f} "
+                           f"(attempt {attempt}/{max_retries}): {response.text[:200]}")
+        except requests.exceptions.RequestException as e:
+            logger.warning(f"Upload of {f} failed (attempt {attempt}/{max_retries}): {e}")
+
+        if attempt < max_retries:
+            wait = 2 ** (attempt - 1)  # 1s, 2s
+            logger.info(f"Retrying in {wait}s...")
+            time.sleep(wait)
+
+    logger.error(f"Failed to upload {f} after {max_retries} attempts")
+    return False
 
 
 def csv_to_json_chunk(csv_file: str, chunk_start: int, chunk_size: int, output_file: str) -> int:
@@ -284,15 +304,16 @@ def bulkload_chunked(csv_file: str,
     return total_loaded
 
 
-def upload_rows_to_solr(rows, columns, base_url, core, processor=None):
+def upload_rows_to_solr(rows, columns, base_url, core, processor=None, max_retries=3):
     """
-    Upload pre-fetched rows to Solr as JSON documents.
+    Upload pre-fetched rows to Solr as JSON documents with retry on failure.
 
     :param rows: List of row tuples from DuckDB fetchmany
     :param columns: List of column names
     :param base_url: Solr base URL
     :param core: Solr core name
     :param processor: Optional Solr processor
+    :param max_retries: Number of attempts before giving up
     :return: Number of documents uploaded
     """
     docs = [dict(zip(columns, row)) for row in rows]
@@ -301,10 +322,27 @@ def upload_rows_to_solr(rows, columns, base_url, core, processor=None):
     url = f'{base_url}/{core}/update/json/docs?commit=false'
     if processor:
         url += f'&processor={processor}'
-    response = session.post(url, data=json_data,
-                           headers={'Content-Type': 'application/json'},
-                           timeout=300)
-    return len(docs) if response.status_code == 200 else 0
+
+    for attempt in range(1, max_retries + 1):
+        try:
+            response = session.post(url, data=json_data,
+                                    headers={'Content-Type': 'application/json'},
+                                    timeout=300)
+            if response.status_code == 200:
+                return len(docs)
+            logger.warning(f"Solr returned {response.status_code} for {len(docs)} docs "
+                           f"(attempt {attempt}/{max_retries}): {response.text[:200]}")
+        except requests.exceptions.RequestException as e:
+            logger.warning(f"Upload of {len(docs)} docs failed "
+                           f"(attempt {attempt}/{max_retries}): {e}")
+
+        if attempt < max_retries:
+            wait = 2 ** (attempt - 1)  # 1s, 2s
+            logger.info(f"Retrying in {wait}s...")
+            time.sleep(wait)
+
+    logger.error(f"Failed to upload {len(docs)} docs to {core} after {max_retries} attempts")
+    return 0
 
 
 def bulkload_duckdb(db_path: str,

--- a/linkml_solr/utils/solr_bulkload.py
+++ b/linkml_solr/utils/solr_bulkload.py
@@ -55,16 +55,17 @@ def get_optimal_worker_count(max_workers: Optional[int] = None) -> int:
     """
     if max_workers is not None:
         return max_workers
-    
-    # Get CPU count
-    cpu_count = os.cpu_count() or 4  # Fallback to 4 if detection fails
-    
-    # For I/O bound HTTP uploads, use CPU count + 50% but cap at reasonable limit
-    # This balances parallelism with system resource usage without being too aggressive
-    optimal = min(int(cpu_count * 1.5), 12)
-    
-    # Minimum of 2 workers for any benefit
-    return max(optimal, 2)
+
+    cpu_count = os.cpu_count() or 4
+
+    # Assume Solr is colocated and sharing CPUs. Reserve roughly half the cores
+    # for Solr indexing, and use the rest for upload workers. The uploads are
+    # I/O-bound (HTTP), so a small number of threads can still saturate the
+    # network link while leaving headroom for Solr's merge/flush threads.
+    optimal = max(cpu_count // 2, 2)
+
+    # Cap to avoid overwhelming Solr's request handler on large machines
+    return min(optimal, 8)
 
 
 def bulkload_file(f,

--- a/linkml_solr/utils/solr_bulkload.py
+++ b/linkml_solr/utils/solr_bulkload.py
@@ -284,80 +284,27 @@ def bulkload_chunked(csv_file: str,
     return total_loaded
 
 
-def query_duckdb_chunk(db_path: str, query: str, offset: int, chunk_size: int) -> tuple:
+def upload_rows_to_solr(rows, columns, base_url, core, processor=None):
     """
-    Query a chunk of data from DuckDB with read-only connection
-    
-    :param db_path: Path to DuckDB database
-    :param query: Base SQL query (without LIMIT/OFFSET)
-    :param offset: Starting row offset
-    :param chunk_size: Number of rows to fetch
-    :return: (results, columns) tuple
-    """
-    try:
-        # Open read-only connection for safety
-        conn = duckdb.connect(db_path, read_only=True)
-        
-        # Add LIMIT/OFFSET to the query
-        chunk_query = f"{query} LIMIT {chunk_size} OFFSET {offset}"
-        
-        result = conn.execute(chunk_query)
-        rows = result.fetchall()
-        columns = [desc[0] for desc in result.description]
-        
-        conn.close()
-        return rows, columns
-    except Exception as e:
-        print(f"Error querying DuckDB chunk at offset {offset}: {e}")
-        return [], []
+    Upload pre-fetched rows to Solr as JSON documents.
 
-
-def upload_duckdb_chunk(db_path: str, query: str, offset: int, chunk_size: int,
-                       base_url: str, core: str, schema: SchemaDefinition, processor: Optional[str] = None) -> int:
-    """
-    Query DuckDB chunk and upload directly to Solr
-    
-    :param db_path: Path to DuckDB database
-    :param query: Base SQL query
-    :param offset: Starting row offset  
-    :param chunk_size: Number of rows to process
+    :param rows: List of row tuples from DuckDB fetchmany
+    :param columns: List of column names
     :param base_url: Solr base URL
     :param core: Solr core name
-    :param schema: LinkML schema definition
+    :param processor: Optional Solr processor
     :return: Number of documents uploaded
     """
-    try:
-        # Query the chunk
-        rows, columns = query_duckdb_chunk(db_path, query, offset, chunk_size)
-        
-        if not rows:
-            return 0
-        
-        # Convert to JSON for Solr
-        docs = [dict(zip(columns, row)) for row in rows]
-        json_data = json.dumps(docs)
-        
-        # Upload directly to Solr
-        session = get_http_session()
-        url = f'{base_url}/{core}/update/json/docs?commit=false'
-        if processor is not None:
-            url = f'{url}&processor={processor}'
-        
-        response = session.post(url, data=json_data, 
-                               headers={'Content-Type': 'application/json'}, 
-                               timeout=300)
-        
-        if response.status_code == 200:
-            print(f"Uploaded chunk offset {offset}: {len(docs)} docs")
-            return len(docs)
-        else:
-            print(f"Error uploading chunk offset {offset}: {response.status_code}")
-            print(f"Error response: {response.text}")
-            return 0
-            
-    except Exception as e:
-        print(f"Error processing DuckDB chunk at offset {offset}: {e}")
-        return 0
+    docs = [dict(zip(columns, row)) for row in rows]
+    json_data = json.dumps(docs)
+    session = get_http_session()
+    url = f'{base_url}/{core}/update/json/docs?commit=false'
+    if processor:
+        url += f'&processor={processor}'
+    response = session.post(url, data=json_data,
+                           headers={'Content-Type': 'application/json'},
+                           timeout=300)
+    return len(docs) if response.status_code == 200 else 0
 
 
 def bulkload_duckdb(db_path: str,
@@ -418,57 +365,61 @@ def bulkload_duckdb(db_path: str,
         
         total_loaded = 0
         processing_start = time.time()
-        
-        # Process chunks in batches to control memory usage
+
+        # Producer-consumer pattern: single query with fetchmany, parallel uploads
+        conn = duckdb.connect(db_path, read_only=True)
+        result = conn.execute(base_query)
+        col_names = [desc[0] for desc in result.description]
+
         with ThreadPoolExecutor(max_workers=actual_workers) as executor:
-            # Create list of all chunk offsets
-            chunk_offsets = list(range(0, total_rows, chunk_size))
-            total_chunks = len(chunk_offsets)
-            
-            print(f"Processing {total_chunks} chunks in batches of {actual_workers} workers")
+            futures = {}
+            chunk_num = 0
             upload_start = time.time()
-            
-            # Process chunks in batches of worker count
-            for batch_start in range(0, len(chunk_offsets), actual_workers):
-                batch_end = min(batch_start + actual_workers, len(chunk_offsets))
-                batch_offsets = chunk_offsets[batch_start:batch_end]
-                
-                print(f"Processing batch {batch_start//actual_workers + 1}/{(total_chunks + actual_workers - 1)//actual_workers}: chunks {batch_start + 1}-{batch_end}")
-                
-                # Submit current batch
-                futures = []
-                for offset in batch_offsets:
-                    future = executor.submit(
-                        upload_duckdb_chunk,
-                        db_path,
-                        base_query,
-                        offset,
-                        chunk_size,
-                        base_url,
-                        core,
-                        schema,
-                        processor
-                    )
-                    futures.append(future)
-                
-                # Wait for current batch to complete
-                for future in as_completed(futures):
+
+            while True:
+                # Drain completed futures to free memory
+                done = [f for f in futures if f.done()]
+                for f in done:
                     try:
-                        docs_loaded = future.result()
-                        total_loaded += docs_loaded
-                        print(f"Progress: {total_loaded:,}/{total_rows:,} documents loaded")
+                        total_loaded += f.result()
                     except Exception as e:
                         print(f"Error in parallel DuckDB chunk processing: {e}")
-            
+                    del futures[f]
+
+                rows = result.fetchmany(chunk_size)
+                if not rows:
+                    break
+
+                future = executor.submit(
+                    upload_rows_to_solr,
+                    rows,
+                    col_names,
+                    base_url,
+                    core,
+                    processor
+                )
+                futures[future] = chunk_num
+                chunk_num += 1
+                print(f"Submitted chunk {chunk_num} ({len(rows)} rows)")
+
+            # Collect remaining futures
+            for future in as_completed(futures):
+                try:
+                    total_loaded += future.result()
+                except Exception as e:
+                    print(f"Error in parallel DuckDB chunk processing: {e}")
+
             upload_time = time.time() - upload_start
             total_processing_time = time.time() - processing_start
-            
+
             # Calculate throughput metrics
             docs_per_sec = total_loaded / total_processing_time if total_processing_time > 0 else 0
             upload_docs_per_sec = total_loaded / upload_time if upload_time > 0 else 0
-            
+
             print(f"DuckDB upload complete! Upload: {upload_time:.2f}s, Total: {total_processing_time:.2f}s")
             print(f"Throughput: {docs_per_sec:,.0f} docs/sec overall, {upload_docs_per_sec:,.0f} docs/sec upload")
+
+        conn.close()
         
         return total_loaded
         


### PR DESCRIPTION
## Summary

- Eliminates **straggler effect**: replaces fixed batch-of-workers processing (which waited for all workers in a batch before starting the next) with continuous task submission to a thread pool
- Eliminates **O(n^2) LIMIT/OFFSET pagination**: replaces per-chunk `LIMIT X OFFSET Y` queries with a single query using `fetchmany()`, avoiding repeated table scans for large tables
- Bounds memory by draining completed futures inline during the read loop

Fixes #17