### PR TITLE
bulkload-db: snapshot source once instead of per-chunk LIMIT/OFFSET

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.8, 3.9]
+        python-version: ["3.10", "3.11"]
     services:
       solr:
         image: solr:8
@@ -18,18 +18,18 @@ jobs:
         ports:
           - 8983:8983
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Sleep for 15 seconds to give Solr time to start
         run: sleep 15s
         shell: bash
       - name: Confirm that Solr is answering
         run: curl -s -o /dev/null -w "%{http_code}" http://localhost:8983/solr/ || exit 1
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry
-        uses: snok/install-poetry@v1.3
+        uses: snok/install-poetry@v1
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
@@ -37,10 +37,10 @@ jobs:
       #  load cached venv if cache exists
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+          key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
       - name: Install dependencies
         run: poetry install --no-interaction
       - name: add test solr core explicitly

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -43,8 +43,8 @@ jobs:
           key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
       - name: Install dependencies
         run: poetry install --no-interaction
-      - name: Ensure setuptools is available (pysolr imports pkg_resources)
-        run: poetry run pip install setuptools
+      - name: Ensure pkg_resources is available (pysolr imports it; setuptools>=81 dropped it)
+        run: poetry run pip install 'setuptools<81'
       - name: add test solr core explicitly
         run: poetry run lsolr add-cores test
       - name: run tests

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -43,6 +43,8 @@ jobs:
           key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
       - name: Install dependencies
         run: poetry install --no-interaction
+      - name: Ensure setuptools is available (pysolr imports pkg_resources)
+        run: poetry run pip install setuptools
       - name: add test solr core explicitly
         run: poetry run lsolr add-cores test
       - name: run tests

--- a/linkml_solr/cli.py
+++ b/linkml_solr/cli.py
@@ -160,13 +160,13 @@ def bulkload(files, format, schema, url, core, processor, chunk_size, parallel_w
 @click.option('--parallel-workers', '-w',
               default=None,
               type=int,
-              help='Number of parallel workers (default: auto-detect based on CPU cores)')
+              help='Number of parallel Solr upload workers (default: 4). DuckDB reads are serial against a one-time snapshot.')
 @click.option('--where',
               help='SQL WHERE clause for filtering data')
 @click.option('--columns',
               help='Comma-separated list of columns to export (default: all)')
 @click.option('--order-by',
-              help='SQL ORDER BY clause for consistent chunking')
+              help='Optional SQL ORDER BY applied while building the snapshot. Not required for correctness; useful only for reproducible run-to-run row order.')
 @click.option('--auto-configure/--no-auto-configure',
               default=True,
               show_default=True,

--- a/linkml_solr/utils/solr_bulkload.py
+++ b/linkml_solr/utils/solr_bulkload.py
@@ -5,7 +5,7 @@ import duckdb
 import tempfile
 import json
 import os
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor, as_completed, wait, FIRST_COMPLETED
 import threading
 import time
 import os
@@ -38,23 +38,15 @@ def _get_multivalued_slots(schema: SchemaDefinition) -> List[SlotDefinitionName]
 
 def get_optimal_worker_count(max_workers: Optional[int] = None) -> int:
     """
-    Determine optimal number of parallel workers based on system capabilities
-    
-    :param max_workers: Maximum workers to use, None for auto-detection
-    :return: Optimal number of workers
+    Pick a default number of parallel upload workers.
+
+    Empirically (Monarch KG, ~1.5M and ~15M row Solr loads) the marginal
+    benefit drops off sharply past 4 workers — Solr indexing becomes the
+    bottleneck. Use 4 by default; allow override via --parallel-workers.
     """
     if max_workers is not None:
-        return max_workers
-    
-    # Get CPU count
-    cpu_count = os.cpu_count() or 4  # Fallback to 4 if detection fails
-    
-    # For I/O bound HTTP uploads, use CPU count + 50% but cap at reasonable limit
-    # This balances parallelism with system resource usage without being too aggressive
-    optimal = min(int(cpu_count * 1.5), 12)
-    
-    # Minimum of 2 workers for any benefit
-    return max(optimal, 2)
+        return max(int(max_workers), 1)
+    return 4
 
 
 def bulkload_file(f,
@@ -284,79 +276,31 @@ def bulkload_chunked(csv_file: str,
     return total_loaded
 
 
-def query_duckdb_chunk(db_path: str, query: str, offset: int, chunk_size: int) -> tuple:
-    """
-    Query a chunk of data from DuckDB with read-only connection
-    
-    :param db_path: Path to DuckDB database
-    :param query: Base SQL query (without LIMIT/OFFSET)
-    :param offset: Starting row offset
-    :param chunk_size: Number of rows to fetch
-    :return: (results, columns) tuple
-    """
+def _upload_docs_to_solr(docs: list, base_url: str, core: str,
+                         processor: Optional[str], chunk_label: str) -> int:
+    """Upload a batch of documents (list of dicts) to Solr via /update/json/docs."""
+    if not docs:
+        return 0
+    session = get_http_session()
+    url = f'{base_url}/{core}/update/json/docs?commit=false'
+    if processor is not None:
+        url = f'{url}&processor={processor}'
     try:
-        # Open read-only connection for safety
-        conn = duckdb.connect(db_path, read_only=True)
-        
-        # Add LIMIT/OFFSET to the query
-        chunk_query = f"{query} LIMIT {chunk_size} OFFSET {offset}"
-        
-        result = conn.execute(chunk_query)
-        rows = result.fetchall()
-        columns = [desc[0] for desc in result.description]
-        
-        conn.close()
-        return rows, columns
-    except Exception as e:
-        print(f"Error querying DuckDB chunk at offset {offset}: {e}")
-        return [], []
-
-
-def upload_duckdb_chunk(db_path: str, query: str, offset: int, chunk_size: int,
-                       base_url: str, core: str, schema: SchemaDefinition, processor: Optional[str] = None) -> int:
-    """
-    Query DuckDB chunk and upload directly to Solr
-    
-    :param db_path: Path to DuckDB database
-    :param query: Base SQL query
-    :param offset: Starting row offset  
-    :param chunk_size: Number of rows to process
-    :param base_url: Solr base URL
-    :param core: Solr core name
-    :param schema: LinkML schema definition
-    :return: Number of documents uploaded
-    """
-    try:
-        # Query the chunk
-        rows, columns = query_duckdb_chunk(db_path, query, offset, chunk_size)
-        
-        if not rows:
-            return 0
-        
-        # Convert to JSON for Solr
-        docs = [dict(zip(columns, row)) for row in rows]
-        json_data = json.dumps(docs)
-        
-        # Upload directly to Solr
-        session = get_http_session()
-        url = f'{base_url}/{core}/update/json/docs?commit=false'
-        if processor is not None:
-            url = f'{url}&processor={processor}'
-        
-        response = session.post(url, data=json_data, 
-                               headers={'Content-Type': 'application/json'}, 
-                               timeout=300)
-        
+        json_data = json.dumps(docs, default=str)
+        response = session.post(
+            url,
+            data=json_data,
+            headers={'Content-Type': 'application/json'},
+            timeout=300,
+        )
         if response.status_code == 200:
-            print(f"Uploaded chunk offset {offset}: {len(docs)} docs")
+            print(f"Uploaded {chunk_label}: {len(docs)} docs")
             return len(docs)
-        else:
-            print(f"Error uploading chunk offset {offset}: {response.status_code}")
-            print(f"Error response: {response.text}")
-            return 0
-            
+        print(f"Error uploading {chunk_label}: HTTP {response.status_code}")
+        print(f"Response: {response.text[:500]}")
+        return 0
     except Exception as e:
-        print(f"Error processing DuckDB chunk at offset {offset}: {e}")
+        print(f"Error uploading {chunk_label}: {e}")
         return 0
 
 
@@ -372,109 +316,126 @@ def bulkload_duckdb(db_path: str,
                    order_by: Optional[str] = None,
                    processor: Optional[str] = None) -> int:
     """
-    Load data from DuckDB database to Solr with parallel processing
-    
-    :param db_path: Path to DuckDB database file
-    :param table_name: Name of table to export
-    :param base_url: Solr base URL
-    :param core: Solr core name
-    :param schema: LinkML schema definition
-    :param chunk_size: Number of rows per chunk
-    :param max_workers: Number of parallel workers (None for auto-detect)
-    :param where_clause: Optional SQL WHERE clause
-    :param columns: Optional comma-separated column list
-    :param order_by: Optional SQL ORDER BY clause
-    :return: Total number of documents loaded
+    Load data from DuckDB (table or view) into Solr.
+
+    Strategy: materialize the (filtered/ordered) source once into a temporary
+    DuckDB snapshot, then stream rows through a single read-only cursor and
+    hand each chunk to a thread pool that POSTs to Solr. This fixes three
+    correctness/performance problems with the prior offset-based approach:
+
+      * Without ORDER BY, parallel ``LIMIT/OFFSET`` workers returned
+        overlapping/missing rows (silently dropping ~20% of input).
+      * With ORDER BY, every worker re-sorted the full source, causing
+        N-way simultaneous sorts and OOM on multi-GB inputs.
+      * When the source was a view, every chunk recomputed the view.
+
+    One materialization, one pass, bounded memory.
     """
+    column_list = columns if columns else "*"
+    actual_workers = get_optimal_worker_count(max_workers)
+    cpu_count = os.cpu_count() or 'unknown'
+
+    if max_workers is None:
+        print(f"Auto-detected {actual_workers} upload workers (CPU cores: {cpu_count})")
+
+    snapshot_fd, snapshot_path = tempfile.mkstemp(suffix='.duckdb', prefix='lsolr_snapshot_')
+    os.close(snapshot_fd)
+    os.unlink(snapshot_path)
+
+    # Allow table_name to be either a bare identifier (qualified into the
+    # attached "src" database) or a parenthesized subquery whose contents the
+    # caller has already qualified with src.* themselves.
+    from_clause = table_name if table_name.lstrip().startswith('(') else f"src.{table_name}"
+    snapshot_query = f"SELECT {column_list} FROM {from_clause}"
+    if where_clause:
+        snapshot_query += f" WHERE {where_clause}"
+    if order_by:
+        snapshot_query += f" ORDER BY {order_by}"
+
     try:
-        # Build SQL query
-        column_list = columns if columns else "*"
-        base_query = f"SELECT {column_list} FROM {table_name}"
-        
-        if where_clause:
-            base_query += f" WHERE {where_clause}"
-        
-        if order_by:
-            base_query += f" ORDER BY {order_by}"
-        
-        # Get total row count with read-only connection
-        conn = duckdb.connect(db_path, read_only=True)
-        count_query = f"SELECT COUNT(*) FROM {table_name}"
-        if where_clause:
-            count_query += f" WHERE {where_clause}"
-            
-        total_rows = conn.execute(count_query).fetchone()[0]
-        conn.close()
-        
-        # Auto-detect optimal worker count
-        actual_workers = get_optimal_worker_count(max_workers)
-        cpu_count = os.cpu_count() or 'unknown'
-        
-        if max_workers is None:
-            print(f"Auto-detected {actual_workers} workers (CPU cores: {cpu_count})")
-        
-        print(f"Processing {total_rows} rows from DuckDB in chunks of {chunk_size} with {actual_workers} parallel workers")
-        print(f"Query: {base_query}")
-        
+        snapshot_start = time.time()
+        print(f"Materializing snapshot from {table_name} into temp DuckDB...")
+        wconn = duckdb.connect(snapshot_path)
+        try:
+            wconn.execute(f"ATTACH '{db_path}' AS src (READ_ONLY)")
+            wconn.execute(f"CREATE TABLE snapshot AS {snapshot_query}")
+            total_rows = wconn.execute("SELECT COUNT(*) FROM snapshot").fetchone()[0]
+            wconn.execute("DETACH src")
+        finally:
+            wconn.close()
+        snapshot_time = time.time() - snapshot_start
+        print(f"Snapshot ready: {total_rows:,} rows in {snapshot_time:.2f}s")
+        if order_by is None:
+            print("Note: no --order-by supplied; snapshot order is whatever the source returned. "
+                  "This is safe (every row appears exactly once) but not reproducible run-to-run.")
+
+        if total_rows == 0:
+            return 0
+
+        upload_start = time.time()
         total_loaded = 0
-        processing_start = time.time()
-        
-        # Process chunks in batches to control memory usage
-        with ThreadPoolExecutor(max_workers=actual_workers) as executor:
-            # Create list of all chunk offsets
-            chunk_offsets = list(range(0, total_rows, chunk_size))
-            total_chunks = len(chunk_offsets)
-            
-            print(f"Processing {total_chunks} chunks in batches of {actual_workers} workers")
-            upload_start = time.time()
-            
-            # Process chunks in batches of worker count
-            for batch_start in range(0, len(chunk_offsets), actual_workers):
-                batch_end = min(batch_start + actual_workers, len(chunk_offsets))
-                batch_offsets = chunk_offsets[batch_start:batch_end]
-                
-                print(f"Processing batch {batch_start//actual_workers + 1}/{(total_chunks + actual_workers - 1)//actual_workers}: chunks {batch_start + 1}-{batch_end}")
-                
-                # Submit current batch
-                futures = []
-                for offset in batch_offsets:
-                    future = executor.submit(
-                        upload_duckdb_chunk,
-                        db_path,
-                        base_query,
-                        offset,
-                        chunk_size,
-                        base_url,
-                        core,
-                        schema,
-                        processor
-                    )
-                    futures.append(future)
-                
-                # Wait for current batch to complete
-                for future in as_completed(futures):
+        in_flight: list = []
+        max_in_flight = max(actual_workers * 2, 2)
+
+        rconn = duckdb.connect(snapshot_path, read_only=True)
+        try:
+            cursor = rconn.execute("SELECT * FROM snapshot")
+            col_names = [d[0] for d in cursor.description]
+
+            with ThreadPoolExecutor(max_workers=actual_workers) as executor:
+                offset = 0
+                while True:
+                    rows = cursor.fetchmany(chunk_size)
+                    if not rows:
+                        break
+                    docs = [dict(zip(col_names, row)) for row in rows]
+                    label = f"chunk offset {offset}"
+                    in_flight.append(executor.submit(
+                        _upload_docs_to_solr, docs, base_url, core, processor, label
+                    ))
+                    offset += len(rows)
+
+                    if len(in_flight) >= max_in_flight:
+                        done, pending = wait(in_flight, return_when=FIRST_COMPLETED)
+                        for fut in done:
+                            try:
+                                total_loaded += fut.result()
+                            except Exception as e:
+                                print(f"Upload worker error: {e}")
+                        in_flight = list(pending)
+                        print(f"Progress: {total_loaded:,}/{total_rows:,} documents uploaded")
+
+                for fut in as_completed(in_flight):
                     try:
-                        docs_loaded = future.result()
-                        total_loaded += docs_loaded
-                        print(f"Progress: {total_loaded:,}/{total_rows:,} documents loaded")
+                        total_loaded += fut.result()
                     except Exception as e:
-                        print(f"Error in parallel DuckDB chunk processing: {e}")
-            
-            upload_time = time.time() - upload_start
-            total_processing_time = time.time() - processing_start
-            
-            # Calculate throughput metrics
-            docs_per_sec = total_loaded / total_processing_time if total_processing_time > 0 else 0
-            upload_docs_per_sec = total_loaded / upload_time if upload_time > 0 else 0
-            
-            print(f"DuckDB upload complete! Upload: {upload_time:.2f}s, Total: {total_processing_time:.2f}s")
-            print(f"Throughput: {docs_per_sec:,.0f} docs/sec overall, {upload_docs_per_sec:,.0f} docs/sec upload")
-        
+                        print(f"Upload worker error: {e}")
+        finally:
+            rconn.close()
+
+        upload_time = time.time() - upload_start
+        total_time = snapshot_time + upload_time
+        docs_per_sec = total_loaded / total_time if total_time > 0 else 0
+        upload_docs_per_sec = total_loaded / upload_time if upload_time > 0 else 0
+        print(f"DuckDB upload complete! Snapshot: {snapshot_time:.2f}s, "
+              f"Upload: {upload_time:.2f}s, Total: {total_time:.2f}s")
+        print(f"Throughput: {docs_per_sec:,.0f} docs/sec overall, "
+              f"{upload_docs_per_sec:,.0f} docs/sec upload phase")
+
         return total_loaded
-        
+
     except Exception as e:
         print(f"Error in DuckDB bulk loading: {e}")
         return 0
+    finally:
+        try:
+            if os.path.exists(snapshot_path):
+                os.unlink(snapshot_path)
+            wal = snapshot_path + '.wal'
+            if os.path.exists(wal):
+                os.unlink(wal)
+        except OSError:
+            pass
 
 
 def _create_csv_chunk(csv_file: str, chunk_start: int, chunk_size: int, output_file: str) -> int:


### PR DESCRIPTION
Fixes #19, #20, #21.

## Summary

The prior `bulkload_duckdb` paginated the source by issuing a fresh `SELECT * FROM <table> [ORDER BY ...] LIMIT N OFFSET M` from each parallel worker, each on its own connection. That one design choice caused three separate problems:

- **#19**: Without `ORDER BY`, different connections were free to return rows in different orders, so chunks could overlap (rows overwritten by id in Solr) and miss rows entirely. Loads silently dropped ~20% of input while reporting success.
- **#20**: With `ORDER BY`, every worker re-sorted the entire source. On multi-GB inputs the 12-way simultaneous sorts exhausted memory; failed chunks contributed zero with no propagated error.
- **#21**: On a DuckDB view, every chunk re-evaluated the full view (50× slowdown reported in the issue).

## Change

Replace the offset paradigm with a snapshot-and-stream model in `bulkload_duckdb`:

1. ATTACH the user's DB read-only into a fresh tempfile DuckDB.
2. `CREATE TABLE snapshot AS SELECT … FROM src.<table> [WHERE …] [ORDER BY …]` — one materialization.
3. Stream the snapshot through a single read-only cursor (`fetchmany(chunk_size)`).
4. Fan out only the Solr POSTs across a `ThreadPoolExecutor` with backpressure (at most `2 × workers` chunks in flight). DuckDB reads stay serial in one connection — the OOM and view-recomputation pathologies can't happen.

Each row in the snapshot is yielded exactly once by the cursor, so the #19 row-loss is gone even without an explicit `ORDER BY`. `--order-by` is now optional and only useful for run-to-run reproducibility.

`table_name` may also be a parenthesized subquery (e.g. `'(SELECT ... FROM src.edges JOIN src.nodes ...) v'`) so callers can drive joins through the snapshot without first defining a view in the source DB.

`query_duckdb_chunk` and `upload_duckdb_chunk` (the old offset workers) are removed — they only existed to serve the broken pattern.

## Default workers: 12 → 4

`get_optimal_worker_count` used to scale to `cpu * 1.5` capped at 12. Benchmarks (below) show parallelism past 4 has no benefit because Solr indexing dominates. New default: 4. Override with `--parallel-workers`.

## Benchmarks (M-series Mac, Solr 8 in Docker, separate `lsolr_bench_solr` on :8984)

Source: monarch-kg.duckdb (~7.7 GB) from monarch-ingest-graph-schema-verify.

### Correctness — synthetic view (LEFT JOIN edges → nodes ×2 → closure_label ×2, LIMIT 500 000)

| Code | Workers | Reported success | Actually committed | Wall time |
| --- | --- | --- | --- | --- |
| OLD | 4 | 500 000 ✅ | **302 262** (40% row loss) | 40.2 s |
| NEW | 4 | 500 000 | 500 000 | 36.8 s |

Same workload, same data — reproduces #19 (silent ~40% loss with parallel + no `ORDER BY` on a view) and shows the fix.

### Throughput — `nodes` table (1 457 305 rows), NEW code

| Workers | numFound | Wall time | Throughput |
| --- | --- | --- | --- |
| 1 | 1 457 305 | 55.1 s | 27 k docs/s |
| 4 | 1 457 305 | 29.2 s | 52 k docs/s |
| 12 | 1 457 305 | 27.9 s | 55 k docs/s |

~2× from 1→4 workers, then plateau — Solr indexing is the bottleneck. Hence the new default of 4.

### Smoke — `denormalized_edges` table (14 988 609 rows), OLD code w=12
~3 161 s, 4 742 docs/s, full count. (The OLD `nodes` run at default workers also happened to land the full count this run; #19 is timing-dependent, but the view test above demonstrates the failure mode reliably.)

A heavier ordered LEFT JOIN view (the shape #21 describes) couldn't complete a single OLD chunk in 5 minutes locally, consistent with the report there.

## Test plan
- [ ] `make test` (unit suite, unaffected — only `bulkload_file` is exercised)
- [ ] Re-run on the real Monarch KG to confirm counts at full scale
- [ ] Sanity-check `--order-by` still works and produces a stable snapshot